### PR TITLE
"ramaze console" was not working with 1.9.2

### DIFF
--- a/lib/ramaze/tool/bin.rb
+++ b/lib/ramaze/tool/bin.rb
@@ -142,7 +142,7 @@ module Ramaze
             require "irb"
             require "irb/completion"
             Ramaze.options.started = true
-            require "start"
+            require "./start"
             IRB.start
             puts "Ramazement has ended, go in peace."
           when /^(?:--?)?h(elp)?$/


### PR DESCRIPTION
I made this change and it seems to be workng now.

Thanks bougyman for helping me fix it.
